### PR TITLE
Fix an error - Cannot use object of type Magento\Framework\Phrase as …

### DIFF
--- a/Plugin/AddConfigPathToCommentPlugin.php
+++ b/Plugin/AddConfigPathToCommentPlugin.php
@@ -44,7 +44,7 @@ navigator.clipboard.writeText(this.innerText).then(
 HTML;
         $result .= $prefix . $path;
 
-        if (isset($data['comment']['model'])) {
+        if (isset($data['comment']) &&isset($data['comment']['model'])) {
             $result .= "<br>Comment model: {$data['comment']['model']}";
         }
 


### PR DESCRIPTION
…array

When opening the Mageplaza module's configuration scope, the following error occurs. It has been identified that this occurs when there is no comment element in the array for some reason.

Cannot use object of type Magento\Framework\Phrase as array.